### PR TITLE
fix conversion of config.Timeout to string

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -265,7 +265,7 @@ func ipmitoolConfig(config IPMIConfig) []string {
 		args = append(args, "-P", config.Password)
 	}
 	if config.Timeout != 0 {
-		args = append(args, "-N", strconv.FormatInt(config.Timeout, 36))
+		args = append(args, "-N", strconv.FormatInt(config.Timeout, 10))
 	}
 	return args
 }


### PR DESCRIPTION
The conversion of config.Timeout for the "-N" parameter used a base of 36 instead of 10 (decimal), causing ipmitool to complain.